### PR TITLE
Fixed extra CLI enviroment variable reference.

### DIFF
--- a/etc/supervisor/conf.d/chromedriver.conf
+++ b/etc/supervisor/conf.d/chromedriver.conf
@@ -1,5 +1,5 @@
 [program:chromedriver]
-command=/usr/local/bin/chromedriver --port=%(ENV_CHROMEDRIVER_PORT)s --whitelisted-ips=%(ENV_CHROMEDRIVER_WHITELISTED_IPS)s --url-base=%(ENV_CHROMEDRIVER_URL_BASE)s $(ENV_CHROMEDRIVER_EXTRA_ARGS)s
+command=/usr/local/bin/chromedriver --port=%(ENV_CHROMEDRIVER_PORT)s --whitelisted-ips=%(ENV_CHROMEDRIVER_WHITELISTED_IPS)s --url-base=%(ENV_CHROMEDRIVER_URL_BASE)s %(ENV_CHROMEDRIVER_EXTRA_ARGS)s
 priority=10
 user=automation
 directory=/home/automation


### PR DESCRIPTION
Hey RobCherry!

When using your docker image, I stumbled upon this tiny bug when trying to see if my custom arguments were set:
```
root@004c3fd0d1ac:/# ps aux
USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root         1  3.1  0.9  57440 19768 ?        Ss   11:34   0:00 /usr/bin/python /usr/local/bin/supervisord -c 
....
automat+    11  0.0  0.2 101620  5496 ?        Sl   11:35   0:00 /usr/local/bin/chromedriver --port=4444 --whitelisted-ips=127.0.0.1 --url-base= $(ENV_CHROMEDRIVER_EXTRA_ARGS)s
```

Since a `$` was used in lieu of `%`, the text was printed literally, as opposed to dereferencing the environment variable.

Thanks again for all your hard work :)