### PR TITLE
[docker] Add arm32v6 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
-FROM debian:jessie
-MAINTAINER Rob Cherry
+ARG ARCH=amd64
+FROM debian:jessie AS base-amd64
 
+# For some super weird reasons the official arm32v6 repo does not support debian but only alpine backed stuff
+FROM armhf/debian:jessie AS base-arm32v6
+
+FROM base-${ARCH} as build
 ENV DEBIAN_FRONTEND noninteractive
 ENV DEBCONF_NONINTERACTIVE_SEEN true
 
@@ -54,6 +58,7 @@ ENV CHROMEDRIVER_PORT 4444
 ENV CHROMEDRIVER_WHITELISTED_IPS "127.0.0.1"
 ENV CHROMEDRIVER_URL_BASE ''
 ENV CHROMEDRIVER_EXTRA_ARGS ''
+MAINTAINER Rob Cherry
 
 EXPOSE 4444
 


### PR DESCRIPTION
This PR add's multi-arch support with `amd64` and `arm32v6` support. It is configure-able like so

```
docker build -t "chromedriver:local" --build-arg ARCH=arm32v6 .
```

This will not touch the default behaviour because `amd64` is set as default.
Uploading a tag via Docker hub is unfortunately not possible, as cross-arch compilation on linux is a bit complicated. If you have an OSX it might be relatively easy to figure out.
I'd like to hold this back for a day until I tested the resulting image on actual hardware.
